### PR TITLE
Add setCellVerticalAlignment() & allow setShouldWrapText() to be expl…

### DIFF
--- a/docs/_pages/documentation.md
+++ b/docs/_pages/documentation.md
@@ -116,19 +116,20 @@ $reader->setShouldPreserveEmptyRows(true);
 
 For fonts and alignments, {{ site.spout_html }} does not support all the possible formatting options yet. But you can find the most important ones:
 
-| Category             | Property       | API
-|:---------------------|:---------------|:--------------------------------------
-| Font                 | Bold           | `StyleBuilder::setFontBold()`
-|                      | Italic         | `StyleBuilder::setFontItalic()`
-|                      | Underline      | `StyleBuilder::setFontUnderline()`
-|                      | Strikethrough  | `StyleBuilder::setFontStrikethrough()`
-|                      | Font name      | `StyleBuilder::setFontName('Arial')`
-|                      | Font size      | `StyleBuilder::setFontSize(14)`
-|                      | Font color     | `StyleBuilder::setFontColor(Color::BLUE)`<br>`StyleBuilder::setFontColor(Color::rgb(0, 128, 255))`
-| Alignment            | Cell alignment | `StyleBuilder::setCellAlignment(CellAlignment::CENTER)`
-|                      | Wrap text      | `StyleBuilder::setShouldWrapText(true)`
-| Format _(XLSX only)_ | Number format  | `StyleBuilder::setFormat('0.000')`
-|                      | Date format    | `StyleBuilder::setFormat('m/d/yy h:mm')`
+| Category             | Property                | API
+|:---------------------|:------------------------|:--------------------------------------
+| Font                 | Bold                    | `StyleBuilder::setFontBold()`
+|                      | Italic                  | `StyleBuilder::setFontItalic()`
+|                      | Underline               | `StyleBuilder::setFontUnderline()`
+|                      | Strikethrough           | `StyleBuilder::setFontStrikethrough()`
+|                      | Font name               | `StyleBuilder::setFontName('Arial')`
+|                      | Font size               | `StyleBuilder::setFontSize(14)`
+|                      | Font color              | `StyleBuilder::setFontColor(Color::BLUE)`<br>`StyleBuilder::setFontColor(Color::rgb(0, 128, 255))`
+| Alignment            | Cell alignment          | `StyleBuilder::setCellAlignment(CellAlignment::CENTER)`
+|                      | Cell vertical alignment | `StyleBuilder::setCellVerticalAlignment(CellVerticalAlignment::CENTER)`
+|                      | Wrap text               | `StyleBuilder::setShouldWrapText(true)`
+| Format _(XLSX only)_ | Number format           | `StyleBuilder::setFormat('0.000')`
+|                      | Date format             | `StyleBuilder::setFormat('m/d/yy h:mm')`
 
 ### Styling rows
 
@@ -150,6 +151,7 @@ $style = (new StyleBuilder())
            ->setFontColor(Color::BLUE)
            ->setShouldWrapText()
            ->setCellAlignment(CellAlignment::RIGHT)
+           ->setCellVerticalAlignment(CellVerticalAlignment::BOTTOM)
            ->setBackgroundColor(Color::YELLOW)
            ->build();
 

--- a/src/Spout/Common/Entity/Style/CellAlignment.php
+++ b/src/Spout/Common/Entity/Style/CellAlignment.php
@@ -3,7 +3,7 @@
 namespace Box\Spout\Common\Entity\Style;
 
 /**
- * Class Alignment
+ * Class CellAlignment
  * This class provides constants to work with text alignment.
  */
 abstract class CellAlignment

--- a/src/Spout/Common/Entity/Style/CellVerticalAlignment.php
+++ b/src/Spout/Common/Entity/Style/CellVerticalAlignment.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Box\Spout\Common\Entity\Style;
+
+/**
+ * Class CellVerticalAlignment
+ * This class provides constants to work with text vertical alignment.
+ */
+abstract class CellVerticalAlignment
+{
+    public const AUTO = 'auto';
+    public const BASELINE = 'baseline';
+    public const BOTTOM = 'bottom';
+    public const CENTER = 'center';
+    public const DISTRIBUTED = 'distributed';
+    public const JUSTIFY = 'justify';
+    public const TOP = 'top';
+
+    private static $VALID_ALIGNMENTS = [
+        self::AUTO => 1,
+        self::BASELINE => 1,
+        self::BOTTOM => 1,
+        self::CENTER => 1,
+        self::DISTRIBUTED => 1,
+        self::JUSTIFY => 1,
+        self::TOP => 1,
+    ];
+
+    /**
+     * @param string $cellVerticalAlignment
+     *
+     * @return bool Whether the given cell vertical alignment is valid
+     */
+    public static function isValid($cellVerticalAlignment)
+    {
+        return isset(self::$VALID_ALIGNMENTS[$cellVerticalAlignment]);
+    }
+}

--- a/src/Spout/Common/Entity/Style/Style.php
+++ b/src/Spout/Common/Entity/Style/Style.php
@@ -61,6 +61,13 @@ class Style
     /** @var bool Whether the cell alignment property was set */
     private $hasSetCellAlignment = false;
 
+    /** @var bool Whether specific cell vertical alignment should be applied */
+    private $shouldApplyCellVerticalAlignment = false;
+    /** @var string Cell vertical alignment */
+    private $cellVerticalAlignment;
+    /** @var bool Whether the cell vertical alignment property was set */
+    private $hasSetCellVerticalAlignment = false;
+
     /** @var bool Whether the text should wrap in the cell (useful for long or multi-lines text) */
     private $shouldWrapText = false;
     /** @var bool Whether the wrap text property was set */
@@ -355,6 +362,14 @@ class Style
     }
 
     /**
+     * @return string
+     */
+    public function getCellVerticalAlignment()
+    {
+        return $this->cellVerticalAlignment;
+    }
+
+    /**
      * @param string $cellAlignment The cell alignment
      *
      * @return Style
@@ -370,6 +385,21 @@ class Style
     }
 
     /**
+     * @param string $cellVerticalAlignment The cell vertical alignment
+     *
+     * @return Style
+     */
+    public function setCellVerticalAlignment($cellVerticalAlignment)
+    {
+        $this->cellVerticalAlignment = $cellVerticalAlignment;
+        $this->hasSetCellVerticalAlignment = true;
+        $this->shouldApplyCellVerticalAlignment = true;
+        $this->isEmpty = false;
+
+        return $this;
+    }
+
+    /**
      * @return bool
      */
     public function hasSetCellAlignment()
@@ -378,11 +408,27 @@ class Style
     }
 
     /**
+     * @return bool
+     */
+    public function hasSetCellVerticalAlignment()
+    {
+        return $this->hasSetCellVerticalAlignment;
+    }
+
+    /**
      * @return bool Whether specific cell alignment should be applied
      */
     public function shouldApplyCellAlignment()
     {
         return $this->shouldApplyCellAlignment;
+    }
+
+    /**
+     * @return bool Whether specific cell alignment should be applied
+     */
+    public function shouldApplyCellVerticalAlignment()
+    {
+        return $this->shouldApplyCellVerticalAlignment;
     }
 
     /**

--- a/src/Spout/Writer/Common/Creator/Style/StyleBuilder.php
+++ b/src/Spout/Writer/Common/Creator/Style/StyleBuilder.php
@@ -4,6 +4,7 @@ namespace Box\Spout\Writer\Common\Creator\Style;
 
 use Box\Spout\Common\Entity\Style\Border;
 use Box\Spout\Common\Entity\Style\CellAlignment;
+use Box\Spout\Common\Entity\Style\CellVerticalAlignment;
 use Box\Spout\Common\Entity\Style\Style;
 use Box\Spout\Common\Exception\InvalidArgumentException;
 
@@ -139,6 +140,25 @@ class StyleBuilder
         }
 
         $this->style->setCellAlignment($cellAlignment);
+
+        return $this;
+    }
+
+    /**
+     * Sets the cell vertical alignment.
+     *
+     * @param string $cellVerticalAlignment The cell vertical alignment
+     *
+     * @throws InvalidArgumentException If the given cell vertical alignment is not valid
+     * @return StyleBuilder
+     */
+    public function setCellVerticalAlignment($cellVerticalAlignment)
+    {
+        if (!CellVerticalAlignment::isValid($cellVerticalAlignment)) {
+            throw new InvalidArgumentException('Invalid cell vertical alignment value');
+        }
+
+        $this->style->setCellVerticalAlignment($cellVerticalAlignment);
 
         return $this;
     }

--- a/src/Spout/Writer/Common/Manager/Style/StyleMerger.php
+++ b/src/Spout/Writer/Common/Manager/Style/StyleMerger.php
@@ -82,11 +82,14 @@ class StyleMerger
      */
     private function mergeCellProperties(Style $styleToUpdate, Style $style, Style $baseStyle)
     {
-        if (!$style->hasSetWrapText() && $baseStyle->shouldWrapText()) {
-            $styleToUpdate->setShouldWrapText();
+        if (!$style->hasSetWrapText() && $baseStyle->hasSetWrapText()) {
+            $styleToUpdate->setShouldWrapText($baseStyle->shouldWrapText());
         }
         if (!$style->hasSetCellAlignment() && $baseStyle->shouldApplyCellAlignment()) {
             $styleToUpdate->setCellAlignment($baseStyle->getCellAlignment());
+        }
+        if (!$style->hasSetCellVerticalAlignment() && $baseStyle->shouldApplyCellVerticalAlignment()) {
+            $styleToUpdate->setCellVerticalAlignment($baseStyle->getCellVerticalAlignment());
         }
         if ($style->getBorder() === null && $baseStyle->shouldApplyBorder()) {
             $styleToUpdate->setBorder($baseStyle->getBorder());

--- a/src/Spout/Writer/XLSX/Manager/Style/StyleManager.php
+++ b/src/Spout/Writer/XLSX/Manager/Style/StyleManager.php
@@ -250,14 +250,17 @@ EOD;
 
             $content .= \sprintf(' applyBorder="%d"', $style->shouldApplyBorder() ? 1 : 0);
 
-            if ($style->shouldApplyCellAlignment() || $style->shouldWrapText()) {
+            if ($style->shouldApplyCellAlignment() || $style->shouldApplyCellVerticalAlignment() || $style->hasSetWrapText()) {
                 $content .= ' applyAlignment="1">';
                 $content .= '<alignment';
                 if ($style->shouldApplyCellAlignment()) {
                     $content .= \sprintf(' horizontal="%s"', $style->getCellAlignment());
                 }
-                if ($style->shouldWrapText()) {
-                    $content .= ' wrapText="1"';
+                if ($style->shouldApplyCellVerticalAlignment()) {
+                    $content .= \sprintf(' vertical="%s"', $style->getCellVerticalAlignment());
+                }
+                if ($style->hasSetWrapText()) {
+                    $content .= ' wrapText="' . ($style->shouldWrapText() ? '1' : '0') . '"';
                 }
                 $content .= '/>';
                 $content .= '</xf>';

--- a/tests/Spout/Writer/Common/Creator/StyleBuilderTest.php
+++ b/tests/Spout/Writer/Common/Creator/StyleBuilderTest.php
@@ -4,6 +4,7 @@ namespace Box\Spout\Writer\Common\Creator\Style;
 
 use Box\Spout\Common\Entity\Style\Border;
 use Box\Spout\Common\Entity\Style\CellAlignment;
+use Box\Spout\Common\Entity\Style\CellVerticalAlignment;
 use Box\Spout\Common\Entity\Style\Color;
 use Box\Spout\Common\Exception\InvalidArgumentException;
 use Box\Spout\Writer\Common\Manager\Style\StyleMerger;
@@ -56,9 +57,27 @@ class StyleBuilderTest extends TestCase
     /**
      * @return void
      */
+    public function testStyleBuilderShouldApplyCellVerticalAlignment()
+    {
+        $style = (new StyleBuilder())->setCellVerticalAlignment(CellVerticalAlignment::CENTER)->build();
+        $this->assertTrue($style->shouldApplyCellVerticalAlignment());
+    }
+
+    /**
+     * @return void
+     */
     public function testStyleBuilderShouldThrowOnInvalidCellAlignment()
     {
         $this->expectException(InvalidArgumentException::class);
         (new StyleBuilder())->setCellAlignment('invalid_cell_alignment')->build();
+    }
+
+    /**
+     * @return void
+     */
+    public function testStyleBuilderShouldThrowOnInvalidCellVerticalAlignment()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        (new StyleBuilder())->setCellVerticalAlignment('invalid_cell_alignment')->build();
     }
 }

--- a/tests/Spout/Writer/ODS/WriterWithStyleTest.php
+++ b/tests/Spout/Writer/ODS/WriterWithStyleTest.php
@@ -191,6 +191,27 @@ class WriterWithStyleTest extends TestCase
     /**
      * @return void
      */
+    public function testAddRowShouldAddNegatedWrapTextAlignmentInfoInStylesXmlFileIfSpecified()
+    {
+        $fileName = 'test_add_row_should_add_negated_wrap_text_alignment.ods';
+
+        $style = (new StyleBuilder())->setShouldWrapText(false)->build();
+        $dataRows = $this->createStyledRowsFromValues([
+            ['ods--11', 'ods--12'],
+        ], $style);
+
+        $this->writeToODSFile($dataRows, $fileName);
+
+        $styleElements = $this->getCellStyleElementsFromContentXmlFile($fileName);
+        $this->assertCount(2, $styleElements, 'There should be 2 styles (default and custom)');
+
+        $customStyleElement = $styleElements[1];
+        $this->assertFirstChildHasAttributeEquals('no-wrap', $customStyleElement, 'table-cell-properties', 'fo:wrap-option');
+    }
+
+    /**
+     * @return void
+     */
     public function testAddRowShouldApplyWrapTextIfCellContainsNewLine()
     {
         $fileName = 'test_add_row_should_apply_wrap_text_if_new_lines.ods';

--- a/tests/Spout/Writer/XLSX/WriterWithStyleTest.php
+++ b/tests/Spout/Writer/XLSX/WriterWithStyleTest.php
@@ -274,6 +274,26 @@ class WriterWithStyleTest extends TestCase
     /**
      * @return void
      */
+    public function testAddRowShouldAddNegatedWrapTextAlignmentInfoInStylesXmlFileIfSpecified()
+    {
+        $fileName = 'test_add_row_should_add_negated_wrap_text_alignment.xlsx';
+
+        $style = (new StyleBuilder())->setShouldWrapText(false)->build();
+        $dataRows = $this->createStyledRowsFromValues([
+            ['xlsx--11', 'xlsx--12'],
+        ], $style);
+
+        $this->writeToXLSXFile($dataRows, $fileName);
+
+        $cellXfsDomElement = $this->getXmlSectionFromStylesXmlFile($fileName, 'cellXfs');
+        $xfElement = $cellXfsDomElement->getElementsByTagName('xf')->item(1);
+        $this->assertEquals(1, $xfElement->getAttribute('applyAlignment'));
+        $this->assertFirstChildHasAttributeEquals('0', $xfElement, 'alignment', 'wrapText');
+    }
+
+    /**
+     * @return void
+     */
     public function testAddRowShouldApplyWrapTextIfCellContainsNewLine()
     {
         $fileName = 'test_add_row_should_apply_wrap_text_if_new_lines.xlsx';


### PR DESCRIPTION
…icitly set as false

- add Common\Entity\Style\CellVerticalAlignment
- duplicate get/set/hasSet/shouldApply methods for CellAlignment in Common\Entity\Style\Style for CellVerticalAlignment instead, plus corresponding properties
- add setCellVerticalAlignment method to Common\Creator\Style\StyleBuilder
- add vertical alignment to StyleMerger:: mergeCellProperties()
- adjust wrapText logic in mergeCellProperties() to fix issue https://github.com/box/spout/issues/829
- apply vertical cell styling for both XLSX and ODS, via corresponding StyleManager classes
- transform vertical alignment  ‘center’ to ‘middle’ for ODS
- fix logic around wrapText such that the choice whether to include wrapping styles depends on hasSetWrapText() being true, and then use shouldWrapText() thereafter to either set wrapping or no wrapping (for XLSX, wrapText=“1” or wrapText=“0”, for ODS, wrap-option=wrap or wrap-option=no-wrap). previously there was no way to set wrapping to be OFF, only to set it to be ON.
- add new tests to ensure shouldWrapText(false) results in the correct negated wrapText (XLSX) / wrap-option (ODS) styles
- add new tests to StyleBuilderTest for vertical alignment
- add vertical alignment to documentation.md